### PR TITLE
3B-G07-W004-PR01. Implement Password Update Option

### DIFF
--- a/services/userService.js
+++ b/services/userService.js
@@ -1,5 +1,6 @@
 import admin from 'firebase-admin';
 import { db } from '@/lib/firebase';
+import { isValidEmail, isValidPassword } from '@/utils/validate';
 
 export async function getAllUsers() {
   const snapshot = await db.ref('users').once('value');
@@ -19,17 +20,36 @@ export async function updateUser(uid, updates) {
   for (const key of allowed) {
     if (updates[key] !== undefined) sanitized[key] = updates[key];
   }
+
+  // email and password live in Firebase Auth, not the Realtime DB.
+  // Build a separate payload for admin.auth().updateUser, and mirror email into the DB.
+  const authUpdates = {};
+  if (updates.email) {
+    if (!isValidEmail(updates.email)) throw new Error('Invalid email format');
+    authUpdates.email = updates.email;
+    sanitized.email = updates.email;
+  }
+  if (updates.password) {
+    if (!isValidPassword(updates.password)) {
+      throw new Error('Password must be at least 6 characters');
+    }
+    authUpdates.password = updates.password;
+  }
+
   sanitized.updatedAt = Date.now();
   await db.ref(`users/${uid}`).update(sanitized);
 
-  // Also update Firebase Auth displayName if name fields changed
-  if (updates.firstName || updates.lastName) {
+  if (updates.firstName || updates.middleName || updates.lastName) {
     const snapshot = await db.ref(`users/${uid}`).once('value');
     const user = snapshot.val();
-    const displayName = [user.firstName, user.middleName, user.lastName]
+    authUpdates.displayName = [user.firstName, user.middleName, user.lastName]
       .filter(Boolean).join(' ');
-    await admin.auth().updateUser(uid, { displayName });
   }
+
+  if (Object.keys(authUpdates).length > 0) {
+    await admin.auth().updateUser(uid, authUpdates);
+  }
+
   return { uid, ...sanitized };
 }
 


### PR DESCRIPTION
## **Summary**
- **What does this change?**
The API route and services finally support updating email and password using Firebase Authentication.

- **Why is it needed?**
It's important to have the option to change your account credentials because it helps you secure your account against cybersecurity incidents. Using Firebase instead of the Realtime Database is also needed because we don't want to store passwords in the database, and Firebase already has built-in authentication middleware.

## **Changes**
- Email and Password are handled via `admin.auth().updateUser()` in Firebase Authentication
- Since email is written in the Realtime Database, while email updates are handled via Firebase. The logic also updates the email in the Realtime Database, writing the same value.

## **Checklist**
- [x] Code follows project guidelines.
- [x] Tested locally and works as expected.
- [x] No breaking changes to existing features.
